### PR TITLE
Add type property to service object

### DIFF
--- a/carol/did.json
+++ b/carol/did.json
@@ -24,6 +24,7 @@
   "assertionMethod": ["#z6MkpzW2izkFjNwMBwwvKqmELaQcH8t54QL5xmBdJg9Xh1y4"],
   "service": [{
     "id":"#github",
+    "type": "https://github.com/",
     "serviceEndpoint": "https://raw.githubusercontent.com"
   }]
 }

--- a/carol/did.json
+++ b/carol/did.json
@@ -24,7 +24,7 @@
   "assertionMethod": ["#z6MkpzW2izkFjNwMBwwvKqmELaQcH8t54QL5xmBdJg9Xh1y4"],
   "service": [{
     "id":"#github",
-    "type": "https://github.com/",
+    "type": "LinkedDomains",
     "serviceEndpoint": "https://raw.githubusercontent.com"
   }]
 }


### PR DESCRIPTION
[DID Core](https://www.w3.org/TR/did-core/#services) requires `type` property:
"Each service map MUST contain id, type, and serviceEndpoint properties"